### PR TITLE
Add support for ghcr.io, including private images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: "docker"
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,8 @@ jobs:
         uses: ./
         with:
           base-image: mcr.microsoft.com/windows/servercore:ltsc2022
-          image: mcr.microsoft.com/windows/servercore/iis:windowsservercore-ltsc2022
+          # mcr.microsoft.com/windows/servercore/iis:windowsservercore also supports different os versions, which this action doesn't
+          image: mcr.microsoft.com/windows/servercore:ltsc2022-KB5034129
           verbose: true
           os: windows
       - name: Get Test Output (Windows)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,24 @@ jobs:
         run: echo "Needs updating (unexpected)"; exit 1
         if: steps.test_does_not_need_updating_linux.outputs.needs-updating == 'true'
 
+      - name: Test Action with needs updating equals true (linux/arm64)
+        id: test_needs_updating_linux_arm64
+        uses: ./
+        with:
+          base-image: index.docker.io/library/nginx:1.21.0
+          image: ubuntu
+          verbose: true
+          os: linux
+          arch: arm64
+      - name: Get Test Output (needs updating)
+        run: 'echo "Needs updating (should be true): ${{ steps.test_needs_updating_linux_arm64.outputs.needs-updating }}"'
+      - name: Check that it needs updating
+        run: echo "Needs updating (as expected)"
+        if: steps.test_needs_updating_linux_arm64.outputs.needs-updating == 'true'
+      - name: Should not run (needs updating should be true)
+        run: echo "Does not need updating (unexpected)"; exit 1
+        if: steps.test_needs_updating_linux_arm64.outputs.needs-updating == 'false'
+
       - name: Test Action with needs updating equals false (Windows)
         id: test_does_not_need_updating_windows
         uses: ./

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
   test:
     name: Test-Action
     runs-on: ubuntu-latest
-    continue-on-error: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3

--- a/action.yml
+++ b/action.yml
@@ -5,10 +5,10 @@ author: Giovanni Bassi <giggio@giggio.net>
 
 inputs:
   base-image:
-    description: "Container base image"
+    description: "Container base image. E.g. nginx, nginx:latest, ghcr.io/greatorg/greatapp:latest"
     required: true
   image:
-    description: "Container image"
+    description: "Container image. E.g. nginx, nginx:latest, ghcr.io/greatorg/greatapp:latest. Can point to a different registry than base-image does."
     required: true
   os:
     description: "OS being used, will default to the OS running the action."
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: "false"
   github_token:
-    description: "Github Token to authenticate against ghcr.io"
+    description: "Github Token to authenticate against ghcr.io, if image or base-image is a private ghcr image."
     required: false
     default: ""
 outputs:

--- a/action.yml
+++ b/action.yml
@@ -1,7 +1,7 @@
 ---
 name: "Registry Image Update Checker"
 description: "GitHub Action to check if the base container image that your image is based on was updated and your image needs to be updated"
-author: Giovanni Bassi <giggio@giggio.net>
+author: Georg Jung <github-actions@gjung.com>
 
 inputs:
   base-image:

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,10 @@ inputs:
     description: "Show verbose output"
     required: false
     default: "false"
+  github_token:
+    description: "Github Token to authenticate against ghcr.io"
+    required: false
+    default: ""
 outputs:
   needs-updating:
     description: "true or false, true if the image needs updating (does not match the base image), false if it does not need updating"
@@ -31,7 +35,7 @@ runs:
   steps:
     - id: run-script
       run: |
-        OUTPUT=`FULL_BASE=${{ inputs.base-image }} FULL_IMAGE=${{ inputs.image }} OS=${{ inputs.os }} ARCH=${{ inputs.arch }} VERBOSE=${{ inputs.verbose }} $GITHUB_ACTION_PATH/docker.sh`
+        OUTPUT=`FULL_BASE=${{ inputs.base-image }} FULL_IMAGE=${{ inputs.image }} OS=${{ inputs.os }} ARCH=${{ inputs.arch }} VERBOSE=${{ inputs.verbose }} GITHUB_TOKEN=${{ inputs.github_token }} $GITHUB_ACTION_PATH/docker.sh`
         if [ "$?" != "0" ]; then
           >&2 echo "Error running update checker action."
           exit 1

--- a/docker.sh
+++ b/docker.sh
@@ -32,7 +32,7 @@ getLayers() {
     fi
     VERSION=`jq -r .schemaVersion <<< "$MANIFESTS"`
     MEDIATYPE=`jq -r .mediaType <<< "$MANIFESTS"`
-    if [ "$VERSION" == '1' ] && [ "$MEDIATYPE" == 'application/vnd.docker.distribution.manifest.list.v2+json' ]; then
+    if [ "$VERSION" == '1' ] ; then
         if [ "$VERBOSE" == "true" ]; then
             echo "Using schema version 1" > "`tty`"
         fi

--- a/docker.sh
+++ b/docker.sh
@@ -106,7 +106,7 @@ getToken() {
         fi
         curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$REPO:pull" | jq -r '.token'
     elif [ "$REGISTRY" == "ghcr.io" ]; then
-        echo $GITHUB_TOKEN | base64
+        echo "$GITHUB_TOKEN" | base64
     else
         echo ""
     fi

--- a/docker.sh
+++ b/docker.sh
@@ -23,7 +23,7 @@ getLayers() {
         AUTH="Authorization: Bearer $AUTH"
     fi
     if [ "$VERBOSE" == "true" ]; then
-        echo curl -s -H "$AUTH" -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" "https://$REGISTRY/v2/$REPO/manifests/$DIGEST_LIST" > "`tty`"
+        echo "curl -s -H \"$AUTH\" -H \"Accept: application/vnd.docker.distribution.manifest.list.v2+json\" \"https://$REGISTRY/v2/$REPO/manifests/$DIGEST_LIST\"" > "`tty`"
     fi
     MANIFESTS=`curl -s -H "$AUTH" -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" "https://$REGISTRY/v2/$REPO/manifests/$DIGEST_LIST"`
     if jq -Mcre '.. | .errors? | select(type == "array" and length != 0)' <<< "$MANIFESTS" > /dev/null; then
@@ -70,7 +70,7 @@ getLayers() {
             exit 1
         fi
         if [ "$VERBOSE" == "true" ]; then
-            echo curl -s -H "$AUTH" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" "https://$REGISTRY/v2/$REPO/manifests/$DIGEST" > "`tty`"
+            echo "curl -s -H \"$AUTH\" -H \"Accept: application/vnd.docker.distribution.manifest.v2+json\" \"https://$REGISTRY/v2/$REPO/manifests/$DIGEST\"" > "`tty`"
         fi
         MANIFEST=`curl -s -H "$AUTH" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" "https://$REGISTRY/v2/$REPO/manifests/$DIGEST"`
         jq -r '.layers[].digest' <<<"$MANIFEST"
@@ -98,7 +98,7 @@ getToken() {
 
     if [ "$REGISTRY" == "index.docker.io" ]; then
         if [ "$VERBOSE" == "true" ]; then
-            echo curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$REPO:pull" > "`tty`"
+            echo "curl -s \"https://auth.docker.io/token?service=registry.docker.io&scope=repository:$REPO:pull\"" > "`tty`"
         fi
         curl -s "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$REPO:pull" | jq -r '.token'
     elif [ "$REGISTRY" == "ghcr.io" ]; then

--- a/docker.sh
+++ b/docker.sh
@@ -41,7 +41,7 @@ getLayers() {
             echo "Using schema version 1" > "`tty`"
         fi
         jq -r '.fsLayers[] | .blobSum' <<< "$MANIFESTS" | tac
-    elif [ "$VERSION" == '2' ] && [[ "$MEDIATYPE" == 'application/vnd.docker.distribution.manifest.list.v2+json' ] || [ "$MEDIATYPE" == 'application/vnd.oci.image.index.v1+json' ]]; then
+    elif [[ "$VERSION" == '2'  && ("$MEDIATYPE" == 'application/vnd.docker.distribution.manifest.list.v2+json' || "$MEDIATYPE" == 'application/vnd.oci.image.index.v1+json') ]]; then
         if [ "$VERBOSE" == "true" ]; then
             echo "Using schema version 2" > "`tty`"
         fi
@@ -78,7 +78,7 @@ getLayers() {
         fi
         MANIFEST=`curl -s -H "$AUTH" -H "Accept: application/vnd.docker.distribution.manifest.v2+json;q=0.9, application/vnd.oci.image.manifest.v1+json;q=0.8" "https://$REGISTRY/v2/$REPO/manifests/$DIGEST"`
         jq -r '.layers[].digest' <<<"$MANIFEST"
-    elif [ "$VERSION" == '2' ] && [[ "$MEDIATYPE" == 'application/vnd.docker.distribution.manifest.v2+json' ] || [ "$MEDIATYPE" == 'application/vnd.oci.image.manifest.v1+json' ]]; then
+    elif [[ "$VERSION" == '2' && ("$MEDIATYPE" == 'application/vnd.docker.distribution.manifest.v2+json' || "$MEDIATYPE" == 'application/vnd.oci.image.manifest.v1+json') ]]; then
         # ghcr gives us a manifest even though we requested a manifest list
         # if we don't use the multiarch functionality, this is fine.
         if [ "$OS" == "" ] && [ "$ARCH" == "" ]; then

--- a/docker.sh
+++ b/docker.sh
@@ -23,13 +23,13 @@ getLayers() {
         AUTH="Authorization: Bearer $AUTH"
     fi
     if [ "$VERBOSE" == "true" ]; then
-        echo "curl -s -H \"$AUTH\" -H \"Accept: application/vnd.docker.distribution.manifest.list.v2+json;q=0.9, application/vnd.docker.distribution.manifest.v2+json;q=0.8\" \"https://$REGISTRY/v2/$REPO/manifests/$DIGEST_LIST\"" > "`tty`"
+        echo "curl -s -H \"$AUTH\" -H \"Accept: application/vnd.docker.distribution.manifest.list.v2+json;q=0.9, application/vnd.oci.image.index.v1+json;q=0.8, application/vnd.docker.distribution.manifest.v2+json;q=0.7\" \"https://$REGISTRY/v2/$REPO/manifests/$DIGEST_LIST\"" > "`tty`"
     fi
     # if we request a manifest list from docker hub for an image that is not multi-arch, it will return
     # a v1 manifest by default; comparison of a v1 manifest of an image to a v2 manifest of a base image indicates
     # updating is needed even if it should not, so it is better to request a manifest.list if possible and a 
     # manifest.v2 otherwise. Maybe we should catch comparing v1 to v2 layers alltogether?
-    MANIFESTS=`curl -s -H "$AUTH" -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json;q=0.9, application/vnd.docker.distribution.manifest.v2+json;q=0.8" "https://$REGISTRY/v2/$REPO/manifests/$DIGEST_LIST"`
+    MANIFESTS=`curl -s -H "$AUTH" -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json;q=0.9, application/vnd.oci.image.index.v1+json;q=0.8, application/vnd.docker.distribution.manifest.v2+json;q=0.7" "https://$REGISTRY/v2/$REPO/manifests/$DIGEST_LIST"`
     if jq -Mcre '.. | .errors? | select(type == "array" and length != 0)' <<< "$MANIFESTS" > /dev/null; then
         >&2 echo "Error getting manifest for repo $REGISTRY/$REPO:$DIGEST_LIST."
         exit 64
@@ -41,7 +41,7 @@ getLayers() {
             echo "Using schema version 1" > "`tty`"
         fi
         jq -r '.fsLayers[] | .blobSum' <<< "$MANIFESTS" | tac
-    elif [ "$VERSION" == '2' ] && [ "$MEDIATYPE" == 'application/vnd.docker.distribution.manifest.list.v2+json' ]; then
+    elif [ "$VERSION" == '2' ] && [[ "$MEDIATYPE" == 'application/vnd.docker.distribution.manifest.list.v2+json' ] || [ "$MEDIATYPE" == 'application/vnd.oci.image.index.v1+json' ]]; then
         if [ "$VERBOSE" == "true" ]; then
             echo "Using schema version 2" > "`tty`"
         fi
@@ -74,11 +74,11 @@ getLayers() {
             exit 1
         fi
         if [ "$VERBOSE" == "true" ]; then
-            echo "curl -s -H \"$AUTH\" -H \"Accept: application/vnd.docker.distribution.manifest.v2+json\" \"https://$REGISTRY/v2/$REPO/manifests/$DIGEST\"" > "`tty`"
+            echo "curl -s -H \"$AUTH\" -H \"Accept: application/vnd.docker.distribution.manifest.v2+json;q=0.9, application/vnd.oci.image.manifest.v1+json;q=0.8\" \"https://$REGISTRY/v2/$REPO/manifests/$DIGEST\"" > "`tty`"
         fi
-        MANIFEST=`curl -s -H "$AUTH" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" "https://$REGISTRY/v2/$REPO/manifests/$DIGEST"`
+        MANIFEST=`curl -s -H "$AUTH" -H "Accept: application/vnd.docker.distribution.manifest.v2+json;q=0.9, application/vnd.oci.image.manifest.v1+json;q=0.8" "https://$REGISTRY/v2/$REPO/manifests/$DIGEST"`
         jq -r '.layers[].digest' <<<"$MANIFEST"
-    elif [ "$VERSION" == '2' ] && [ "$MEDIATYPE" == 'application/vnd.docker.distribution.manifest.v2+json' ]; then
+    elif [ "$VERSION" == '2' ] && [[ "$MEDIATYPE" == 'application/vnd.docker.distribution.manifest.v2+json' ] || [ "$MEDIATYPE" == 'application/vnd.oci.image.manifest.v1+json' ]]; then
         # ghcr gives us a manifest even though we requested a manifest list
         # if we don't use the multiarch functionality, this is fine.
         if [ "$OS" == "" ] && [ "$ARCH" == "" ]; then

--- a/docker.sh
+++ b/docker.sh
@@ -36,6 +36,10 @@ getLayers() {
     fi
     VERSION=`jq -r .schemaVersion <<< "$MANIFESTS"`
     MEDIATYPE=`jq -r .mediaType <<< "$MANIFESTS"`
+    if [ "$VERBOSE" == "true" ]; then
+        echo "Fetched MANIFESTS content:" > "`tty`"
+        echo "$MANIFESTS" > "`tty`"
+    fi
     if [ "$VERSION" == '1' ] ; then
         if [ "$VERBOSE" == "true" ]; then
             echo "Using schema version 1" > "`tty`"


### PR DESCRIPTION
* GHCR does not support manifest lists
* This also works for private container images on ghcr

Typical use case: We have an internal app that is developed on github and the container images are on ghcr, not publicly accessible. The app is based on a public image that is hosted on docker hub, for example `nginx:latest`. With these changes, that use case works for me.

Thanks for providing this great action!
